### PR TITLE
fix: Remove tests for python 3.7

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -25,7 +25,7 @@ jobs:
           path: ~/Library/Caches/pip
         - os: windows-latest
           path: ~\AppData\Local\pip\Cache
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Pre-commit is broken for Python 3.7 due to the importlib newest release. 
This fix is to temporary remove the tests for 3.7 until it is fixed.